### PR TITLE
Add external_tracker and external_wiki

### DIFF
--- a/src/api/repos/edit.rs
+++ b/src/api/repos/edit.rs
@@ -1,7 +1,10 @@
 use build_it::Builder;
 use serde::Serialize;
 
-use crate::{error::Result, model::repos::Repository};
+use crate::{
+    error::Result,
+    model::repos::{ExternalTracker, ExternalWiki, Repository},
+};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Builder)]
 #[build_it(into)]
@@ -44,6 +47,10 @@ pub struct EditRepoBuilder {
     description: Option<String>,
     /// Enable prune - remove obsolete remote-tracking references when mirroring
     enable_prune: Option<bool>,
+    /// ExternalTracker represents settings for external tracker
+    external_tracker: Option<ExternalTracker>,
+    /// ExternalWiki represents setting for external wiki
+    external_wiki: Option<ExternalWiki>,
     /// Either `true` to enable actions unit, or `false` to disable them.
     has_actions: Option<bool>,
     /// Either `true` to enable issues for this repository or `false` to disable them.
@@ -97,6 +104,8 @@ impl EditRepoBuilder {
             default_merge_style: None,
             description: None,
             enable_prune: None,
+            external_tracker: None,
+            external_wiki: None,
             has_actions: None,
             has_issues: None,
             has_packages: None,

--- a/src/api/repos/edit.rs
+++ b/src/api/repos/edit.rs
@@ -126,7 +126,10 @@ impl EditRepoBuilder {
     pub async fn send(&self, client: &crate::Client) -> Result<Repository> {
         let owner = &self.owner;
         let repo = &self.repo;
-        let req = client.patch(format!("repos/{owner}/{repo}")).build()?;
+        let req = client
+            .patch(format!("repos/{owner}/{repo}"))
+            .json(&self)
+            .build()?;
         let res = client.make_request(req).await?;
         client.parse_response(res).await
     }

--- a/src/model/repos.rs
+++ b/src/model/repos.rs
@@ -58,6 +58,8 @@ pub struct Repository {
     pub default_merge_style: String,
     pub description: String,
     pub empty: bool,
+    pub external_tracker: ExternalTracker,
+    pub external_wiki: ExternalWiki,
     pub fork: bool,
     pub forks_count: i64,
     pub full_name: String,
@@ -190,4 +192,26 @@ pub struct Branch {
     pub status_check_contexts: Vec<String>,
     pub user_can_merge: bool,
     pub user_can_push: bool,
+}
+
+/// ExternalTracker represents settings for external tracker
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(default)]
+pub struct ExternalTracker {
+    /// External Issue Tracker URL Format. Use the placeholders {user}, {repo} and {index} for the username, repository name and issue index.
+    pub external_tracker_format: String,
+    /// External Issue Tracker issue regular expression
+    pub external_tracker_regexp_pattern: String,
+    /// External Issue Tracker Number Format, either numeric, alphanumeric, or regexp
+    pub external_tracker_style: String,
+    /// URL of external issue tracker.
+    pub external_tracker_url: String,
+}
+
+/// ExternalWiki represents setting for external wiki
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(default)]
+pub struct ExternalWiki {
+    /// URL of external wiki.
+    pub external_wiki_url: String,
 }


### PR DESCRIPTION
Hi! Thanks for your work on this crate, it's much appreciated.

I was in need to query and update repositories' external tracker and wiki and wrote a rudimentary implementation. While working with EditRepoBuilder, I noticed the request in send() missing the payload, which I added as well.

Hope this helps!