### PR TITLE
feat(repos): get repository content

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitea-sdk"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 description = "An unofficial Gitea API client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitea-sdk"
-version = "0.6.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT"
 description = "An unofficial Gitea API client"

--- a/src/api/issues/comments/get.rs
+++ b/src/api/issues/comments/get.rs
@@ -1,6 +1,3 @@
-use build_it::Builder;
-use serde::Serialize;
-
 use crate::{error::Result, model::issues::Comment, Client};
 
 #[derive(Debug, Clone)]

--- a/src/api/repos/contents/get.rs
+++ b/src/api/repos/contents/get.rs
@@ -1,0 +1,57 @@
+use build_it::Builder;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{model::repos::Entry, Result};
+
+#[derive(Debug, Serialize, Deserialize, Builder)]
+#[build_it(into)]
+pub struct GetContentsRepoBuilder {
+    #[skip]
+    #[serde(skip)]
+    owner: String,
+
+    #[skip]
+    #[serde(skip)]
+    repo: String,
+
+    #[skip]
+    #[serde(skip)]
+    filepath: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[build_it(rename = "refs")]
+    r#ref: Option<String>,
+}
+
+impl GetContentsRepoBuilder {
+    pub fn new(owner: impl ToString, repo: impl ToString, filepath: impl ToString) -> Self {
+        Self {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            filepath: filepath.to_string(),
+            r#ref: None,
+        }
+    }
+
+    /// Send the request to fetch given repository's file path contents.
+    pub async fn send(&self, client: &crate::Client) -> Result<Vec<Entry>> {
+        let owner = &self.owner;
+        let repo = &self.repo;
+        let filepath = &self.filepath;
+        let req = client
+            .get(format!("repos/{owner}/{repo}/contents/{filepath}"))
+            .query(self)
+            .build()?;
+        let res = client.make_request(req).await?;
+
+        let res_body: Value = res.json().await?;
+
+        // Response can either be Entry or Entry[], put in Vec<> to handle both cases
+        let entries = serde_json::from_value::<Vec<Entry>>(res_body.clone()).or_else(|_| {
+            serde_json::from_value(res_body.clone()).map(|single_entry| vec![single_entry])
+        })?;
+
+        Ok(entries)
+    }
+}

--- a/src/api/repos/contents/get.rs
+++ b/src/api/repos/contents/get.rs
@@ -7,18 +7,19 @@ use crate::{model::repos::Entry, Result};
 #[derive(Debug, Serialize, Deserialize, Builder)]
 #[build_it(into)]
 pub struct GetContentsRepoBuilder {
+    /// The owner of the repository.
     #[skip]
     #[serde(skip)]
     owner: String,
-
+    /// The name of the repository.
     #[skip]
     #[serde(skip)]
     repo: String,
-
+    /// The entry filepath can be a directory or file.
     #[skip]
     #[serde(skip)]
     filepath: String,
-
+    /// The name of the commit/branch/tag. Default the repository’s default branch (usually master)
     #[serde(skip_serializing_if = "Option::is_none")]
     #[build_it(rename = "refs")]
     r#ref: Option<String>,

--- a/src/api/repos/contents/mod.rs
+++ b/src/api/repos/contents/mod.rs
@@ -1,0 +1,42 @@
+use crate::api::repos::contents;
+
+pub mod get;
+
+pub struct Contents {
+    pub(crate) owner: String,
+    pub(crate) repo: String,
+}
+
+impl Contents {
+    /// Gets the metadata and contents (if a file) of an entry in a repository, or a list of entries if a dir
+    /// This will return a list of all [Entry](crate::model::repos::Entry) objects
+    ///
+    /// # Example
+    /// ```
+    /// # use gitea_sdk::{Client, Auth};
+    /// # async fn fetch_repo_content() {
+    /// let client = Client::new(
+    ///     "https://gitea.example.com",
+    ///     Auth::Token("your-token")
+    /// );
+    /// let src_entries = client
+    ///     .repos("repo-owner", "repo-name")
+    ///     .contents()
+    ///     .get("src")
+    ///     .send(&client)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// let main_file_entry = client
+    ///     .repos("repo-owner", "repo-name")
+    ///     .contents()
+    ///     .get("src/main.rs")
+    ///     .send(&client)
+    ///     .await
+    ///     .unwrap();
+    /// # }
+    /// ```
+    pub fn get(&self, filepath: impl ToString) -> contents::get::GetContentsRepoBuilder {
+        contents::get::GetContentsRepoBuilder::new(self.owner.clone(), self.repo.clone(), filepath)
+    }
+}

--- a/src/api/repos/mod.rs
+++ b/src/api/repos/mod.rs
@@ -1,5 +1,6 @@
 pub mod branches;
 pub mod commits;
+pub mod contents;
 pub mod delete;
 pub mod edit;
 pub mod forks;
@@ -306,5 +307,12 @@ impl Repos {
     /// This will delete the branch "branch-to-delete" in the repository "owner/repo".
     pub fn delete_branch(&self, branch: impl ToString) -> branches::DeleteBranchBuilder {
         branches::DeleteBranchBuilder::new(&self.owner, &self.repo, branch)
+    }
+
+    pub fn contents(&self) -> contents::Contents {
+        contents::Contents {
+            owner: self.owner.clone(),
+            repo: self.repo.clone(),
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ use reqwest::StatusCode;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TeatimeErrorKind {
     HttpError,
+    ParseError,
     SerializationError,
     Other,
 }
@@ -14,6 +15,7 @@ impl Display for TeatimeErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             TeatimeErrorKind::HttpError => write!(f, "HTTP error"),
+            TeatimeErrorKind::ParseError => write!(f, "Parsing error"),
             TeatimeErrorKind::SerializationError => write!(f, "Serialization error"),
             TeatimeErrorKind::Other => write!(f, "error"),
         }
@@ -52,6 +54,16 @@ impl From<reqwest::Error> for TeatimeError {
             message: format!("{}", err),
             status_code: err.status().unwrap_or(StatusCode::BAD_REQUEST),
             kind,
+        }
+    }
+}
+
+impl From<serde_json::Error> for TeatimeError {
+    fn from(err: serde_json::Error) -> Self {
+        TeatimeError {
+            message: format!("{}", err),
+            status_code: StatusCode::BAD_REQUEST,
+            kind: TeatimeErrorKind::ParseError,
         }
     }
 }

--- a/src/model/repos.rs
+++ b/src/model/repos.rs
@@ -215,3 +215,35 @@ pub struct ExternalWiki {
     /// URL of external wiki.
     pub external_wiki_url: String,
 }
+
+/// Links contains related resource URLs for a file entry.
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Links {
+    pub git: String,
+    pub html: String,
+    #[serde(rename = "self")]
+    pub self_link: String,
+}
+
+/// Entry represents metadata and contents of a file
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(default)]
+pub struct Entry {
+    #[serde(rename = "_links")]
+    pub links: Links,
+    pub content: Option<String>,
+    pub download_url: Option<String>,
+    pub encoding: Option<String>,
+    pub git_url: String,
+    pub html_url: String,
+    pub last_commit_sha: String,
+    pub name: String,
+    pub path: Option<String>,
+    pub sha: String,
+    pub size: u64,
+    pub submodule_git_url: Option<String>,
+    pub target: Option<String>,
+    #[serde(rename = "type")]
+    pub r#type: String,
+    pub url: String,
+}

--- a/src/model/repos.rs
+++ b/src/model/repos.rs
@@ -216,9 +216,9 @@ pub struct ExternalWiki {
     pub external_wiki_url: String,
 }
 
-/// Links contains related resource URLs for a file entry.
+/// FileLinks contains related resource URLs for a file entry.
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Links {
+pub struct FileLinks {
     /// Resource Git URL
     pub git: String,
     /// Resource HTML URL
@@ -234,7 +234,7 @@ pub struct Links {
 pub struct Entry {
     /// Entry links
     #[serde(rename = "_links")]
-    pub links: Links,
+    pub links: FileLinks,
     /// Entry content
     pub content: Option<String>,
     /// Entry download URL

--- a/src/model/repos.rs
+++ b/src/model/repos.rs
@@ -219,9 +219,12 @@ pub struct ExternalWiki {
 /// Links contains related resource URLs for a file entry.
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Links {
+    /// Resource Git URL
     pub git: String,
+    /// Resource HTML URL
     pub html: String,
     #[serde(rename = "self")]
+    /// Resource self link
     pub self_link: String,
 }
 
@@ -229,21 +232,36 @@ pub struct Links {
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(default)]
 pub struct Entry {
+    /// Entry links
     #[serde(rename = "_links")]
     pub links: Links,
+    /// Entry content
     pub content: Option<String>,
+    /// Entry download URL
     pub download_url: Option<String>,
+    /// Entry encoding type
     pub encoding: Option<String>,
+    /// Entry Git url
     pub git_url: String,
+    /// Entry HTML url
     pub html_url: String,
+    /// Entry last commit SHA
     pub last_commit_sha: String,
+    /// Entry name
     pub name: String,
+    /// Entry path
     pub path: Option<String>,
+    /// Entry SHA
     pub sha: String,
+    /// Entry size
     pub size: u64,
+    /// Entry submodule git url
     pub submodule_git_url: Option<String>,
+    /// Entry target
     pub target: Option<String>,
+    /// Entry type
     #[serde(rename = "type")]
     pub r#type: String,
+    /// Entry URL
     pub url: String,
 }


### PR DESCRIPTION
Hi @benpueschel,

First, I would like to thank you for taking time to maintain teatime as this is the only up-to-date gitea Rust crate I could find that is still actively maintained, keep up the good work ! :100: 

I have opened this P.R to change the following things : 

- Support GET `/repos/{owner}/{repo}/contents/{filepath}` endpoint

- Support GET `/repos/{owner}/{repo}/contents/` endpoint ( basically by supporting the endpoint with {filepath} we automatically support this one since we only have to pass '/' as the arg to get the repo's root dir )

- Remove unused imports ( in comments/get.rs )

- Bump the crate version to 0.6.0

Feel free to get back to me if you have any questions about these changes

Have a nice day !