### PR TITLE
fix(model/pulls): Accept review_comments being omitted in API response

### DIFF
--- a/src/model/pulls.rs
+++ b/src/model/pulls.rs
@@ -38,6 +38,8 @@ pub struct PullRequest {
     pub pin_order: i64,
     pub requested_reviewers: Option<Vec<Option<User>>>,
     /// Number of review comments made on the diff of a PR review (not including comments on commits or issues in a PR)
+    // Gitea has this marked as `omitempty` so it's omitted when zero.
+    #[serde(default)]
     pub review_comments: i64,
     pub state: StateType,
     pub title: String,


### PR DESCRIPTION
This field is marked as `omitempty` in Gitea, which appears to mean it's emitted when zero (but if you know Go better than me please correct me!).
So we should allow it to be missing when deserialising.

(Fixes `pulls().get(pr_number)`)

See: https://github.com/go-gitea/gitea/blob/915b44810dffc44fba5e6ee2cd68e8311d958fe8/modules/structs/pull.go#L46