### PR TITLE
fix(model/pulls): allow additions, changed_files, deletions to be omitted for 0

### DIFF
--- a/src/model/pulls.rs
+++ b/src/model/pulls.rs
@@ -8,15 +8,18 @@ use super::{
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PullRequest {
+    #[serde(default)]
     pub additions: i64,
     pub allow_maintainer_edit: bool,
     pub assignees: Option<Vec<User>>,
     pub base: PrBranchInfo,
     pub body: String,
+    #[serde(default)]
     pub changed_files: i64,
     pub closed_at: Option<String>,
     pub comments: i64,
     pub created_at: String,
+    #[serde(default)]
     pub deletions: i64,
     pub diff_url: String,
     pub draft: bool,


### PR DESCRIPTION
Seems I have paid the price for being too lazy to check thoroughly for other cases of https://github.com/benpueschel/teatime/pull/24 :)

These are also omitempty:
https://github.com/go-gitea/gitea/blob/427954ba6ed3a553f75eb1d01fb2f4597e3eda1c/modules/structs/pull.go#L49

I've had a look for others and am not seeing any, but that's no guarantee.